### PR TITLE
DirectoryCheckerをPythonで再実装

### DIFF
--- a/.github/resources/check_directory_script.py
+++ b/.github/resources/check_directory_script.py
@@ -3,8 +3,6 @@ import os
 import sys
 
 print("Directory Checker")
-# Found hjson files: 249
-
 
 csv_file = "TranslatedMods.csv"
 f = open(csv_file, newline="", encoding="utf-8")
@@ -14,7 +12,7 @@ header = next(reader)
 lines = list(enumerate(reader, start=2))
 
 print(f"Found entries: {len(lines)}")
-print("Checking directories:")
+print("\nChecking directories:")
 
 failureMods = []
 for line_num, line in lines:

--- a/.github/resources/check_directory_script.py
+++ b/.github/resources/check_directory_script.py
@@ -1,0 +1,47 @@
+import csv
+import os
+import sys
+
+print("Directory Checker")
+# Found hjson files: 249
+
+
+csv_file = "TranslatedMods.csv"
+f = open(csv_file, newline="", encoding="utf-8")
+
+reader = csv.reader(f)
+header = next(reader)
+lines = list(enumerate(reader, start=2))
+
+print(f"Found entries: {len(lines)}")
+print("Checking directories:")
+
+failureMods = []
+for line_num, line in lines:
+    if len(line) < 3:
+        continue
+
+    mod_name = line[2].strip()
+
+    if os.path.isdir(mod_name):
+        print(f"\t\033[32mOK\033[0m: {mod_name}")
+    else:
+        print(
+            f"::error file=TranslatedMods.csv,line={line_num}::Directory '{mod_name}' does not exist"
+        )
+        print(f"\t\033[31mFAIL\033[0m: {mod_name}")
+        failureMods.append(mod_name)
+
+f.close()
+
+print("\nSummary:")
+print("\t\033[32mSuccess\033[0m:", len(lines) - len(failureMods))
+print("\t\033[31mFailure\033[0m:", len(failureMods))
+
+if len(failureMods) > 0:
+    print("\n\033[31mFailed directories:\033[0m")
+    for mod in failureMods:
+        print(f"\t- {mod}")
+
+if len(failureMods) > 0:
+    sys.exit(1)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,19 +36,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13' 
+
       - name: Check Directory Structure
-        run: |
-          line_number=1
-          error_found=0
+        run: python .github/resources/check_directory_script.py
 
-          while read -r internal_name; do
-              line_number=$((line_number + 1))
-              if [ ! -d "$internal_name" ]; then
-                  echo "::error file=TranslatedMods.csv,line=$line_number::Directory $internal_name does not exist"
-                  error_found=1
-              fi
-          done < <(tail -n +2 TranslatedMods.csv | cut -d',' -f3)
-
-          if [ $error_found -eq 1 ]; then
-            exit 1
-          fi


### PR DESCRIPTION
## 概要

DirectoryCheckerをPythonで再実装

ダブルクオーテーションによるコンマの無視に非対応だったため。


